### PR TITLE
Enable new vllm prompt attention api

### DIFF
--- a/python/sglang/srt/layers/attention/hpu_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hpu_attn_backend.py
@@ -61,11 +61,13 @@ class HPUAttnBackend(AttentionBackend):
         value = v.view(1, -1, layer.tp_v_head_num, layer.v_head_dim)
 
         output = ops.prompt_attention(
-            query,
-            key,
-            value,
+            "fsdpa",
+            query=query,
+            key=key,
+            value=value,
             attn_bias=forward_batch.attn_bias,
             p=0.0,
+            is_causal=True,
             scale=layer.scaling,
             matmul_qk_op=self.matmul_qk,
             softmax_op=self.softmax,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -187,8 +187,7 @@ class TpModelWorker:
         next_token_ids = next_token_ids.to("cpu")
         next_token_ids = next_token_ids[:forward_batch.real_batch_size]
 
-        # TODO: Need to return logits_output in the future
-        return None, next_token_ids
+        return logits_output, next_token_ids
 
     def forward_batch_embedding(self, model_worker_batch: ModelWorkerBatch):
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)


### PR DESCRIPTION
This allows the latest API for prompt attention from `vllm-hpu-extension`. 