### PR TITLE
Overlap schedule backup

### DIFF
--- a/examples/runtime/engine/offline_batch_inference.py
+++ b/examples/runtime/engine/offline_batch_inference.py
@@ -21,7 +21,7 @@ def main(
         "The future of AI is",
     ]
     # Create a sampling params object.
-    sampling_params = {"temperature": 0.8, "top_p": 0.95}
+    sampling_params = {"temperature": 0.8, "top_p": 0.95, "max_new_tokens": 10}
 
     # Create an LLM.
     llm = sgl.Engine(**dataclasses.asdict(server_args))

--- a/examples/runtime/engine/offline_batch_inference.py
+++ b/examples/runtime/engine/offline_batch_inference.py
@@ -21,11 +21,14 @@ def main(
         "The future of AI is",
     ]
     # Create a sampling params object.
-    sampling_params = {"temperature": 0.8, "top_p": 0.95, "max_new_tokens": 10}
+    sampling_params = {"temperature": 0.8, "top_p": 0.95, "max_new_tokens": 20}
 
     # Create an LLM.
     llm = sgl.Engine(**dataclasses.asdict(server_args))
 
+    print("starting warmup")
+    outputs = llm.generate(prompts, sampling_params)
+    print("finished warmup")
     outputs = llm.generate(prompts, sampling_params)
     # Print the outputs.
     for prompt, output in zip(prompts, outputs):

--- a/examples/runtime/engine/offline_batch_inference.py
+++ b/examples/runtime/engine/offline_batch_inference.py
@@ -21,7 +21,7 @@ def main(
         "The future of AI is",
     ]
     # Create a sampling params object.
-    sampling_params = {"temperature": 0.8, "top_p": 0.95, "max_new_tokens": 20}
+    sampling_params = {"temperature": 0.0, "top_p": 0.95, "max_new_tokens": 20}
 
     # Create an LLM.
     llm = sgl.Engine(**dataclasses.asdict(server_args))

--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -227,7 +227,7 @@ def throughput_test_once(
             "SGLANG_TORCH_PROFILER_DIR" in os.environ
         ), "Please set SGLANG_TORCH_PROFILER_DIR."
         os.makedirs(os.environ["SGLANG_TORCH_PROFILER_DIR"], exist_ok=True)
-        backend.start_profile()
+        backend.start_profile(activities=["CPU", "HPU"])
 
     st = time.perf_counter()
     gen_out = backend.generate(prompt=prompt, sampling_params=sampling_params)

--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -340,68 +340,69 @@ def throughput_test(
     # Warm up
     if not bench_args.skip_warmup:
         logging.info("\nWarmup...")
-        for i in range(1):
-            throughput_test_once(
-                backend_name=bench_args.backend,
-                backend=backend,
-                reqs=input_requests,
-                ignore_eos=not bench_args.disable_ignore_eos,
-                extra_request_body=extra_request_body,
-                profile=False,
-            )
-            time.sleep(0.5)
+        throughput_test_once(
+            backend_name=bench_args.backend,
+            backend=backend,
+            reqs=input_requests,
+            ignore_eos=not bench_args.disable_ignore_eos,
+            extra_request_body=extra_request_body,
+            profile=False,
+        )
+        time.sleep(0.5)
 
     logging.info("\nBenchmark...")
-    result = throughput_test_once(
-        backend_name=bench_args.backend,
-        backend=backend,
-        reqs=input_requests,
-        ignore_eos=not bench_args.disable_ignore_eos,
-        extra_request_body=extra_request_body,
-        profile=bench_args.profile,
-    )
+    for i in range(2):
+        result = throughput_test_once(
+            backend_name=bench_args.backend,
+            backend=backend,
+            reqs=input_requests,
+            ignore_eos=not bench_args.disable_ignore_eos,
+            extra_request_body=extra_request_body,
+            profile=bench_args.profile,
+        )
+        print(
+            "\n{s:{c}^{n}}".format(s=" Offline Throughput Benchmark Result ", n=50, c="=")
+        )
+        print("{:<40} {:<10}".format("Backend:", result["backend"]))
+        print("{:<40} {:<10}".format("Successful requests:", result["successful_requests"]))
+        print("{:<40} {:<10.2f}".format("Benchmark duration (s):", result["total_latency"]))
+        print("{:<40} {:<10}".format("Total input tokens:", result["total_input_tokens"]))
+        print(
+            "{:<40} {:<10}".format("Total generated tokens:", result["total_output_tokens"])
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Last generation throughput (tok/s):", result["last_gen_throughput"]
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Request throughput (req/s):", result["request_throughput"]
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Input token throughput (tok/s):", result["input_throughput"]
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Output token throughput (tok/s):", result["output_throughput"]
+            )
+        )
+        print(
+            "{:<40} {:<10.2f}".format(
+                "Total token throughput (tok/s):", result["total_throughput"]
+            )
+        )
+        print("=" * 50)
     backend.shutdown()
 
     if bench_args.result_filename:
         with open(bench_args.result_filename, "a") as fout:
             fout.write(json.dumps(result) + "\n")
 
-    print(
-        "\n{s:{c}^{n}}".format(s=" Offline Throughput Benchmark Result ", n=50, c="=")
-    )
-    print("{:<40} {:<10}".format("Backend:", result["backend"]))
-    print("{:<40} {:<10}".format("Successful requests:", result["successful_requests"]))
-    print("{:<40} {:<10.2f}".format("Benchmark duration (s):", result["total_latency"]))
-    print("{:<40} {:<10}".format("Total input tokens:", result["total_input_tokens"]))
-    print(
-        "{:<40} {:<10}".format("Total generated tokens:", result["total_output_tokens"])
-    )
-    print(
-        "{:<40} {:<10.2f}".format(
-            "Last generation throughput (tok/s):", result["last_gen_throughput"]
-        )
-    )
-    print(
-        "{:<40} {:<10.2f}".format(
-            "Request throughput (req/s):", result["request_throughput"]
-        )
-    )
-    print(
-        "{:<40} {:<10.2f}".format(
-            "Input token throughput (tok/s):", result["input_throughput"]
-        )
-    )
-    print(
-        "{:<40} {:<10.2f}".format(
-            "Output token throughput (tok/s):", result["output_throughput"]
-        )
-    )
-    print(
-        "{:<40} {:<10.2f}".format(
-            "Total token throughput (tok/s):", result["total_throughput"]
-        )
-    )
-    print("=" * 50)
+
 
     return result
 

--- a/python/sglang/bench_offline_throughput.py
+++ b/python/sglang/bench_offline_throughput.py
@@ -303,6 +303,9 @@ def throughput_test(
     server_args: ServerArgs,
     bench_args: BenchArgs,
 ):
+    tokenizer_id = server_args.tokenizer_path or server_args.model_path
+    tokenizer = get_tokenizer(tokenizer_id)
+    input_requests = get_dataset(bench_args, tokenizer)
     if bench_args.backend == "engine":
         backend = Engine(**dataclasses.asdict(server_args))
         if not backend:
@@ -311,9 +314,6 @@ def throughput_test(
         backend = Runtime(**dataclasses.asdict(server_args))
     else:
         raise ValueError('Please set backend to either "engine" or "runtime"')
-
-    tokenizer_id = server_args.tokenizer_path or server_args.model_path
-    tokenizer = get_tokenizer(tokenizer_id)
 
     # Set global environmnets
     set_ulimit()
@@ -326,29 +326,30 @@ def throughput_test(
         extra_request_body = json.loads(args.extra_request_body)
 
     # Read dataset
-    input_requests = get_dataset(bench_args, tokenizer)
+    
 
-    warmup_requests = sample_random_requests(
-        input_len=256,
-        output_len=16,
-        num_prompts=min(bench_args.num_prompts, 16),
-        range_ratio=1.0,
-        tokenizer=tokenizer,
-        dataset_path=bench_args.dataset_path,
-    )
+    # warmup_requests = sample_random_requests(
+    #     input_len=256,
+    #     output_len=16,
+    #     num_prompts=min(bench_args.num_prompts, 16),
+    #     range_ratio=1.0,
+    #     tokenizer=tokenizer,
+    #     dataset_path=bench_args.dataset_path,
+    # )
 
     # Warm up
     if not bench_args.skip_warmup:
         logging.info("\nWarmup...")
-        throughput_test_once(
-            backend_name=bench_args.backend,
-            backend=backend,
-            reqs=warmup_requests,
-            ignore_eos=not bench_args.disable_ignore_eos,
-            extra_request_body=extra_request_body,
-            profile=False,
-        )
-        time.sleep(0.5)
+        for i in range(1):
+            throughput_test_once(
+                backend_name=bench_args.backend,
+                backend=backend,
+                reqs=input_requests,
+                ignore_eos=not bench_args.disable_ignore_eos,
+                extra_request_body=extra_request_body,
+                profile=False,
+            )
+            time.sleep(0.5)
 
     logging.info("\nBenchmark...")
     result = throughput_test_once(

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -242,8 +242,8 @@ def extend(reqs, model_runner):
     batch.prepare_for_extend()
     model_worker_batch = batch.get_model_worker_batch()
     forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
-    from sglang.srt.model_executor.forward_batch_info import HPUForwardBatch
-    hpu_forward_batch = HPUForwardBatch.from_forward_batch(forward_batch)
+    from sglang.srt.model_executor.forward_batch_info import create_hpu_forward_batch
+    hpu_forward_batch = create_hpu_forward_batch(forward_batch)
     logits_output = model_runner.forward(hpu_forward_batch)
     logits_output.trim_output(forward_batch.real_batch_size)
     next_token_ids = model_runner.sample(logits_output, forward_batch)
@@ -256,8 +256,8 @@ def decode(input_token_ids, batch, model_runner):
     batch.prepare_for_decode()
     model_worker_batch = batch.get_model_worker_batch()
     forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
-    from sglang.srt.model_executor.forward_batch_info import HPUForwardBatch
-    hpu_forward_batch = HPUForwardBatch.from_forward_batch(forward_batch)
+    from sglang.srt.model_executor.forward_batch_info import create_hpu_forward_batch
+    hpu_forward_batch = create_hpu_forward_batch(forward_batch)
     logits_output = model_runner.forward(hpu_forward_batch)
     logits_output.trim_output(forward_batch.real_batch_size)
     next_token_ids = model_runner.sample(logits_output, forward_batch)

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -242,7 +242,10 @@ def extend(reqs, model_runner):
     batch.prepare_for_extend()
     model_worker_batch = batch.get_model_worker_batch()
     forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
-    logits_output = model_runner.forward(forward_batch)
+    from sglang.srt.model_executor.forward_batch_info import HPUForwardBatch
+    hpu_forward_batch = HPUForwardBatch.from_forward_batch(forward_batch)
+    logits_output = model_runner.forward(hpu_forward_batch)
+    logits_output.trim_output(forward_batch.real_batch_size)
     next_token_ids = model_runner.sample(logits_output, forward_batch)
     return next_token_ids, logits_output.next_token_logits, batch
 
@@ -253,7 +256,10 @@ def decode(input_token_ids, batch, model_runner):
     batch.prepare_for_decode()
     model_worker_batch = batch.get_model_worker_batch()
     forward_batch = ForwardBatch.init_new(model_worker_batch, model_runner)
-    logits_output = model_runner.forward(forward_batch)
+    from sglang.srt.model_executor.forward_batch_info import HPUForwardBatch
+    hpu_forward_batch = HPUForwardBatch.from_forward_batch(forward_batch)
+    logits_output = model_runner.forward(hpu_forward_batch)
+    logits_output.trim_output(forward_batch.real_batch_size)
     next_token_ids = model_runner.sample(logits_output, forward_batch)
     return next_token_ids, logits_output.next_token_logits
 

--- a/python/sglang/bench_one_batch.py
+++ b/python/sglang/bench_one_batch.py
@@ -245,9 +245,10 @@ def extend(reqs, model_runner):
     from sglang.srt.model_executor.forward_batch_info import create_hpu_forward_batch
     hpu_forward_batch = create_hpu_forward_batch(forward_batch)
     logits_output = model_runner.forward(hpu_forward_batch)
-    logits_output.trim_output(forward_batch.real_batch_size)
     next_token_ids = model_runner.sample(logits_output, forward_batch)
-    return next_token_ids, logits_output.next_token_logits, batch
+    next_token_ids = next_token_ids.to("cpu")
+    next_token_ids = next_token_ids[:forward_batch.real_batch_size]
+    return next_token_ids, None, batch
 
 
 @torch.no_grad
@@ -259,9 +260,10 @@ def decode(input_token_ids, batch, model_runner):
     from sglang.srt.model_executor.forward_batch_info import create_hpu_forward_batch
     hpu_forward_batch = create_hpu_forward_batch(forward_batch)
     logits_output = model_runner.forward(hpu_forward_batch)
-    logits_output.trim_output(forward_batch.real_batch_size)
     next_token_ids = model_runner.sample(logits_output, forward_batch)
-    return next_token_ids, logits_output.next_token_logits
+    next_token_ids = next_token_ids.to("cpu")
+    next_token_ids = next_token_ids[:forward_batch.real_batch_size]
+    return next_token_ids, None
 
 
 def correctness_test(

--- a/python/sglang/srt/custom_op.py
+++ b/python/sglang/srt/custom_op.py
@@ -3,11 +3,11 @@ from typing import Optional
 import torch
 from torch import nn
 
-from sglang.srt.utils import is_cuda, is_hip
+from sglang.srt.utils import is_cuda, is_hip, is_hpu
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
-
+_is_hpu = is_hpu()
 
 class CustomOp(nn.Module):
     def __init__(self):
@@ -40,6 +40,8 @@ class CustomOp(nn.Module):
             return self.forward_cuda
         elif _is_hip:
             return self.forward_hip
+        elif _is_hpu:
+            return self.forward_hpu
         else:
             return self.forward_native
 

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -256,9 +256,11 @@ class Engine:
         self.shutdown()
         return False
 
-    def start_profile(self):
+    def start_profile(self, activities: Optional[List[str]] = None):
+        if activities is None:
+            activities = ["CPU", "GPU"]
         loop = asyncio.get_event_loop()
-        loop.run_until_complete(self.tokenizer_manager.start_profile())
+        loop.run_until_complete(self.tokenizer_manager.start_profile(activities=activities))
 
     def stop_profile(self):
         self.tokenizer_manager.stop_profile()

--- a/python/sglang/srt/layers/attention/hpu_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hpu_attn_backend.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+from torch.nn.functional import scaled_dot_product_attention
+import vllm_hpu_extension.kernels as kernels
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+import vllm_hpu_extension.ops as ops
+from vllm_hpu_extension.utils import (Matmul, ModuleFusedSDPA, Softmax,
+                                      VLLMKVCache)
+
+if TYPE_CHECKING:
+    from sglang.srt.layers.radix_attention import RadixAttention
+    from sglang.srt.model_executor.model_runner import ModelRunner
+
+
+class HPUAttnBackend(AttentionBackend):
+    def __init__(self, model_runner: ModelRunner):
+        super().__init__()
+        self.forward_metadata = None
+        self.device = model_runner.device
+        self.k_cache = VLLMKVCache()
+        self.v_cache = VLLMKVCache()
+        from habana_frameworks.torch.hpex.kernels import FusedSDPA
+        self.fused_scaled_dot_product_attention = ModuleFusedSDPA(
+                    FusedSDPA)
+        self.matmul_qk = Matmul()
+        self.softmax = Softmax()
+        self.matmul_av = Matmul()
+        self.batch2block_matmul = Matmul()
+        self.block2batch_matmul = Matmul()
+
+
+    def init_forward_metadata(self, forward_batch: ForwardBatch):
+        """Init the metadata for a forward pass."""
+        pass
+
+
+    def _run_sdpa_forward_decode(
+        self,
+        query: torch.Tensor,
+        output: torch.Tensor,
+        k_cache: torch.Tensor,
+        v_cache: torch.Tensor,
+        req_to_token: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        seq_lens: torch.Tensor,
+        scaling=None,
+        enable_gqa=False,
+        causal=False,
+    ):
+        """Run the decode forward by using torch native sdpa op.
+
+        Args:
+            query: [num_tokens, num_heads, head_size]
+            output: [num_tokens, num_heads, head_size]
+            k_cache: [max_total_num_tokens, num_heads, head_size]
+            v_cache: [max_total_num_tokens, num_heads, head_size]
+            req_to_token: [max_num_reqs, max_context_len]
+            req_pool_indices: [num_seqs]
+            seq_lens: [num_seqs]
+            scaling: float or None
+            enable_gqa: bool
+            causal: bool
+
+        Returns:
+            output: [num_tokens, num_heads, head_size]
+        """
+
+        # [num_tokens, num_heads, head_size] -> [num_heads, num_tokens, head_size]
+        query = query.movedim(0, query.dim() - 2)
+
+        start_q, start_kv = 0, 0
+        for seq_idx in range(seq_lens.shape[0]):
+            # TODO: this loop process a sequence per iter, this is inefficient.
+            # Need optimize the performance later.
+
+            seq_len_q = 1
+            seq_len_kv = seq_lens[seq_idx]
+            end_q = start_q + seq_len_q
+            end_kv = start_kv + seq_len_kv
+
+            per_req_query = query[:, start_q:end_q, :]
+
+            # get key and value from cache. per_req_tokens contains the kv cache
+            # index for each token in the sequence.
+            req_pool_idx = req_pool_indices[seq_idx]
+            per_req_tokens = req_to_token[req_pool_idx, :seq_len_kv]
+            per_req_key = k_cache[per_req_tokens].movedim(0, query.dim() - 2)
+            per_req_value = v_cache[per_req_tokens].movedim(0, query.dim() - 2)
+
+            per_req_out = (
+                scaled_dot_product_attention(
+                    per_req_query.unsqueeze(0),
+                    per_req_key.unsqueeze(0),
+                    per_req_value.unsqueeze(0),
+                    enable_gqa=enable_gqa,
+                    scale=scaling,
+                    is_causal=causal,
+                )
+                .squeeze(0)
+                .movedim(query.dim() - 2, 0)
+            )
+            output[start_q:end_q, :, :] = per_req_out
+            start_q, start_kv = end_q, end_kv
+
+        return output
+
+    def _get_indices_and_offsets(self, slot_mapping, block_size, is_prompt):
+        slot_mapping = slot_mapping.flatten()
+        indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
+        if is_prompt:
+            indices = indices.unflatten(0, (-1, block_size))[:, 0]
+            offsets = None
+        else:
+            offsets = torch.fmod(slot_mapping, block_size)
+
+        return indices, offsets
+
+    def forward_extend(
+        self,
+        q,
+        k,
+        v,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+    ):
+
+        if save_kv_cache:
+            forward_batch.token_to_kv_pool.set_kv_buffer(
+                layer, forward_batch.out_cache_loc, k, v
+            )
+
+        query = q.view(1, -1, layer.tp_q_head_num, layer.qk_head_dim)
+        key = k.view(1, -1, layer.tp_k_head_num, layer.qk_head_dim)
+        value = v.view(1, -1, layer.tp_v_head_num, layer.v_head_dim)
+
+        output = ops.prompt_attention(
+            query,
+            key,
+            value,
+            attn_bias=forward_batch.attn_bias,
+            p=0.0,
+            scale=layer.scaling,
+            matmul_qk_op=self.matmul_qk,
+            softmax_op=self.softmax,
+            matmul_av_op=self.matmul_av,
+            valid_seq_lengths=forward_batch.valid_seq_len,
+            fsdpa_op=self.fused_scaled_dot_product_attention,
+        )
+        output = output.reshape(q.shape)
+
+        return output
+
+    def forward_decode(
+        self,
+        q,
+        k,
+        v,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+        save_kv_cache=True,
+    ):
+        # During torch.compile, there is a bug in rotary_emb that causes the
+        # output value to have a 3D tensor shape. This reshapes the output correctly.
+        q = q.reshape(-1, layer.tp_q_head_num * layer.qk_head_dim)
+
+        if layer.qk_head_dim != layer.v_head_dim:
+            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+        else:
+            o = torch.empty_like(q)
+
+        if save_kv_cache:
+            forward_batch.token_to_kv_pool.set_kv_buffer(
+                layer, forward_batch.out_cache_loc, k, v
+            )
+
+        use_gqa = layer.tp_q_head_num != layer.tp_k_head_num
+
+        q_ = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+        o_ = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+
+        self._run_sdpa_forward_decode(
+            q_,
+            o_,
+            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
+            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
+            forward_batch.req_to_token_pool.req_to_token,
+            forward_batch.req_pool_indices,
+            forward_batch.seq_lens,
+            scaling=layer.scaling,
+            enable_gqa=use_gqa,
+            causal=False,
+        )
+
+        return o

--- a/python/sglang/srt/layers/attention/hpu_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hpu_attn_backend.py
@@ -98,7 +98,7 @@ class HPUAttnBackend(AttentionBackend):
         key_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
         value_cache = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
 
-        query = q.view(forward_batch.batch_size, 1, layer.tp_q_head_num * layer.qk_head_dim)
+        query = q.view(-1, 1, layer.tp_q_head_num * layer.qk_head_dim)
         key_cache = key_cache.view(-1, forward_batch.page_size, layer.tp_k_head_num, layer.qk_head_dim)
         value_cache = value_cache.view(-1, forward_batch.page_size, layer.tp_v_head_num, layer.v_head_dim)
 

--- a/python/sglang/srt/layers/attention/hpu_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hpu_attn_backend.py
@@ -36,89 +36,10 @@ class HPUAttnBackend(AttentionBackend):
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init the metadata for a forward pass."""
-        pass
+        import vllm_hpu_extension.environment as environment
+        # TODO: remove the hardcoded model_type once we have a better way to handle this
+        environment.runtime_params['model_type'] = 'llama'
 
-
-    def _run_sdpa_forward_decode(
-        self,
-        query: torch.Tensor,
-        output: torch.Tensor,
-        k_cache: torch.Tensor,
-        v_cache: torch.Tensor,
-        req_to_token: torch.Tensor,
-        req_pool_indices: torch.Tensor,
-        seq_lens: torch.Tensor,
-        scaling=None,
-        enable_gqa=False,
-        causal=False,
-    ):
-        """Run the decode forward by using torch native sdpa op.
-
-        Args:
-            query: [num_tokens, num_heads, head_size]
-            output: [num_tokens, num_heads, head_size]
-            k_cache: [max_total_num_tokens, num_heads, head_size]
-            v_cache: [max_total_num_tokens, num_heads, head_size]
-            req_to_token: [max_num_reqs, max_context_len]
-            req_pool_indices: [num_seqs]
-            seq_lens: [num_seqs]
-            scaling: float or None
-            enable_gqa: bool
-            causal: bool
-
-        Returns:
-            output: [num_tokens, num_heads, head_size]
-        """
-
-        # [num_tokens, num_heads, head_size] -> [num_heads, num_tokens, head_size]
-        query = query.movedim(0, query.dim() - 2)
-
-        start_q, start_kv = 0, 0
-        for seq_idx in range(seq_lens.shape[0]):
-            # TODO: this loop process a sequence per iter, this is inefficient.
-            # Need optimize the performance later.
-
-            seq_len_q = 1
-            seq_len_kv = seq_lens[seq_idx]
-            end_q = start_q + seq_len_q
-            end_kv = start_kv + seq_len_kv
-
-            per_req_query = query[:, start_q:end_q, :]
-
-            # get key and value from cache. per_req_tokens contains the kv cache
-            # index for each token in the sequence.
-            req_pool_idx = req_pool_indices[seq_idx]
-            per_req_tokens = req_to_token[req_pool_idx, :seq_len_kv]
-            per_req_key = k_cache[per_req_tokens].movedim(0, query.dim() - 2)
-            per_req_value = v_cache[per_req_tokens].movedim(0, query.dim() - 2)
-
-            per_req_out = (
-                scaled_dot_product_attention(
-                    per_req_query.unsqueeze(0),
-                    per_req_key.unsqueeze(0),
-                    per_req_value.unsqueeze(0),
-                    enable_gqa=enable_gqa,
-                    scale=scaling,
-                    is_causal=causal,
-                )
-                .squeeze(0)
-                .movedim(query.dim() - 2, 0)
-            )
-            output[start_q:end_q, :, :] = per_req_out
-            start_q, start_kv = end_q, end_kv
-
-        return output
-
-    def _get_indices_and_offsets(self, slot_mapping, block_size, is_prompt):
-        slot_mapping = slot_mapping.flatten()
-        indices = torch.div(slot_mapping, block_size, rounding_mode="floor")
-        if is_prompt:
-            indices = indices.unflatten(0, (-1, block_size))[:, 0]
-            offsets = None
-        else:
-            offsets = torch.fmod(slot_mapping, block_size)
-
-        return indices, offsets
 
     def forward_extend(
         self,
@@ -167,34 +88,37 @@ class HPUAttnBackend(AttentionBackend):
     ):
         # During torch.compile, there is a bug in rotary_emb that causes the
         # output value to have a 3D tensor shape. This reshapes the output correctly.
-        q = q.reshape(-1, layer.tp_q_head_num * layer.qk_head_dim)
-
-        if layer.qk_head_dim != layer.v_head_dim:
-            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
-        else:
-            o = torch.empty_like(q)
 
         if save_kv_cache:
             forward_batch.token_to_kv_pool.set_kv_buffer(
                 layer, forward_batch.out_cache_loc, k, v
             )
 
-        use_gqa = layer.tp_q_head_num != layer.tp_k_head_num
+        # Get key and value caches
+        key_cache = forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        value_cache = forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id)
 
-        q_ = q.view(-1, layer.tp_q_head_num, layer.qk_head_dim)
-        o_ = o.view(-1, layer.tp_q_head_num, layer.v_head_dim)
+        query = q.view(forward_batch.batch_size, 1, layer.tp_q_head_num * layer.qk_head_dim)
+        key_cache = key_cache.view(-1, forward_batch.page_size, layer.tp_k_head_num, layer.qk_head_dim)
+        value_cache = value_cache.view(-1, forward_batch.page_size, layer.tp_v_head_num, layer.v_head_dim)
 
-        self._run_sdpa_forward_decode(
-            q_,
-            o_,
-            forward_batch.token_to_kv_pool.get_key_buffer(layer.layer_id),
-            forward_batch.token_to_kv_pool.get_value_buffer(layer.layer_id),
-            forward_batch.req_to_token_pool.req_to_token,
-            forward_batch.req_pool_indices,
-            forward_batch.seq_lens,
-            scaling=layer.scaling,
-            enable_gqa=use_gqa,
-            causal=False,
+        # Run paged attention decode
+        output = ops.flat_pa(
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            block_list=forward_batch.block_list,
+            block_mapping=forward_batch.block_mapping,
+            block_bias=forward_batch.attn_bias,
+            block_scales=forward_batch.block_scales,
+            block_groups=forward_batch.block_groups,
+            scale=layer.scaling,
+            matmul_qk_op=self.matmul_qk,
+            matmul_av_op=self.matmul_av,
+            batch2block_matmul_op=self.batch2block_matmul,
+            block2batch_matmul_op=self.block2batch_matmul,
+            keys_fetch_func=self.k_cache.fetch_from_cache,
+            values_fetch_func=self.v_cache.fetch_from_cache,
         )
 
-        return o
+        return output.reshape(-1, layer.tp_q_head_num * layer.v_head_dim)

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -74,6 +74,40 @@ class LogitsProcessorOutput:
     input_token_ids_logprobs_val: Optional[List] = None
     input_token_ids_logprobs_idx: Optional[List] = None
 
+    def trim_output(self, real_batch_size: int):
+        if self.next_token_logits is not None:
+            self.next_token_logits = self.next_token_logits[:real_batch_size]
+
+        if self.hidden_states is not None:
+            self.hidden_states = self.hidden_states[:real_batch_size]
+
+        if self.next_token_logprobs is not None:
+            self.next_token_logprobs = self.next_token_logprobs[:real_batch_size]
+
+        if self.next_token_top_logprobs_val is not None:
+            self.next_token_top_logprobs_val = self.next_token_top_logprobs_val[:real_batch_size]
+        if self.next_token_top_logprobs_idx is not None:
+            self.next_token_top_logprobs_idx = self.next_token_top_logprobs_idx[:real_batch_size]
+
+        if self.next_token_token_ids_logprobs_val is not None:
+            self.next_token_token_ids_logprobs_val = self.next_token_token_ids_logprobs_val[:real_batch_size]
+        if self.next_token_token_ids_logprobs_idx is not None:
+            self.next_token_token_ids_logprobs_idx = self.next_token_token_ids_logprobs_idx[:real_batch_size]
+
+        if self.input_token_logprobs is not None:
+            self.input_token_logprobs = self.input_token_logprobs[:real_batch_size]
+
+        if self.input_top_logprobs_val is not None:
+            self.input_top_logprobs_val = self.input_top_logprobs_val[:real_batch_size]
+        if self.input_top_logprobs_idx is not None:
+            self.input_top_logprobs_idx = self.input_top_logprobs_idx[:real_batch_size]
+
+        if self.input_token_ids_logprobs_val is not None:
+            self.input_token_ids_logprobs_val = self.input_token_ids_logprobs_val[:real_batch_size]
+        if self.input_token_ids_logprobs_idx is not None:
+            self.input_token_ids_logprobs_idx = self.input_token_ids_logprobs_idx[:real_batch_size]
+
+
 
 @dataclasses.dataclass
 class LogitsMetadata:

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -74,40 +74,6 @@ class LogitsProcessorOutput:
     input_token_ids_logprobs_val: Optional[List] = None
     input_token_ids_logprobs_idx: Optional[List] = None
 
-    def trim_output(self, real_batch_size: int):
-        if self.next_token_logits is not None:
-            self.next_token_logits = self.next_token_logits[:real_batch_size]
-
-        if self.hidden_states is not None:
-            self.hidden_states = self.hidden_states[:real_batch_size]
-
-        if self.next_token_logprobs is not None:
-            self.next_token_logprobs = self.next_token_logprobs[:real_batch_size]
-
-        if self.next_token_top_logprobs_val is not None:
-            self.next_token_top_logprobs_val = self.next_token_top_logprobs_val[:real_batch_size]
-        if self.next_token_top_logprobs_idx is not None:
-            self.next_token_top_logprobs_idx = self.next_token_top_logprobs_idx[:real_batch_size]
-
-        if self.next_token_token_ids_logprobs_val is not None:
-            self.next_token_token_ids_logprobs_val = self.next_token_token_ids_logprobs_val[:real_batch_size]
-        if self.next_token_token_ids_logprobs_idx is not None:
-            self.next_token_token_ids_logprobs_idx = self.next_token_token_ids_logprobs_idx[:real_batch_size]
-
-        if self.input_token_logprobs is not None:
-            self.input_token_logprobs = self.input_token_logprobs[:real_batch_size]
-
-        if self.input_top_logprobs_val is not None:
-            self.input_top_logprobs_val = self.input_top_logprobs_val[:real_batch_size]
-        if self.input_top_logprobs_idx is not None:
-            self.input_top_logprobs_idx = self.input_top_logprobs_idx[:real_batch_size]
-
-        if self.input_token_ids_logprobs_val is not None:
-            self.input_token_ids_logprobs_val = self.input_token_ids_logprobs_val[:real_batch_size]
-        if self.input_token_ids_logprobs_idx is not None:
-            self.input_token_ids_logprobs_idx = self.input_token_ids_logprobs_idx[:real_batch_size]
-
-
 
 @dataclasses.dataclass
 class LogitsMetadata:

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -524,6 +524,8 @@ class Req:
 
 bid = 0
 
+from sglang.srt.utils import is_hpu
+IS_HPU = is_hpu()
 
 @dataclasses.dataclass
 class ScheduleBatch:
@@ -978,7 +980,7 @@ class ScheduleBatch:
         if self.token_to_kv_pool_allocator.page_size == 1:
             out_cache_loc = self.alloc_token_slots(extend_num_tokens)
         else:
-            if self.device == "hpu":
+            if IS_HPU:
                 out_cache_loc = self.alloc_paged_token_slots_extend_hpu(
                     reqs, extend_lens
                 )
@@ -1143,7 +1145,7 @@ class ScheduleBatch:
                 token_indices = self.req_to_token_pool.req_to_token[
                     req.req_pool_idx, : seq_lens_cpu[idx]
                 ]
-                if self.device == "hpu":
+                if IS_HPU:
                     self.token_to_kv_pool_allocator.free(req.req_pool_idx)
                 else:
                     self.token_to_kv_pool_allocator.free(token_indices)
@@ -1258,7 +1260,7 @@ class ScheduleBatch:
             last_loc = self.req_to_token_pool.req_to_token[
                 self.req_pool_indices, self.seq_lens - 2
             ]
-            if self.device == "hpu":
+            if IS_HPU:
                 self.out_cache_loc = self.alloc_paged_token_slots_decode_hpu(
                     self.reqs
                 )

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1015,7 +1015,7 @@ class ScheduleBatch:
         self.extend_input_logprob_token_ids = extend_input_logprob_token_ids
 
         # Write to req_to_token_pool
-        if global_server_args_dict["attention_backend"] != "torch_native":
+        if global_server_args_dict["attention_backend"] not in ["torch_native", "hpu"]:
             # TODO: some tensors can be reused for ForwardBatchInfo (e.g., extend_lens, cumsum_start)
 
             write_req_to_token_pool_triton[(bs,)](

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -708,6 +708,41 @@ class ScheduleBatch:
             raise RuntimeError(error_msg)
         return out_cache_loc
 
+    def alloc_paged_token_slots_extend_hpu(
+        self,
+        reqs: List[Req],
+        extend_lens: List[int],
+    ):
+        extend_num_tokens = sum(extend_lens)
+        batch_size = len(reqs)
+        if (
+            self.token_to_kv_pool_allocator.available_size()
+            < extend_num_tokens
+            + batch_size * self.token_to_kv_pool_allocator.page_size
+        ):
+            if self.tree_cache is not None:
+                self.tree_cache.evict(
+                    extend_num_tokens
+                    + batch_size * self.token_to_kv_pool_allocator.page_size,
+                )
+
+        id_len_pairs = [(req.req_pool_idx, extend_lens[i]) for i, req in enumerate(reqs)]
+        out_cache_loc = self.token_to_kv_pool_allocator.alloc_extend(
+            id_len_pairs
+        )
+        out_cache_loc = torch.tensor(out_cache_loc, dtype=torch.int64, device=self.device)
+        if out_cache_loc is None:
+            error_msg = (
+                f"Prefill out of memory. Try to lower your batch size.\n"
+                f"Try to allocate {extend_num_tokens} tokens.\n"
+                f"Avaliable tokens: {self.token_to_kv_pool_allocator.available_size() + self.tree_cache.evictable_size()}\n"
+                f"{self.token_to_kv_pool_allocator.available_size()=}\n"
+                f"{self.tree_cache.evictable_size()=}\n"
+            )
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
+        return out_cache_loc
+
     def alloc_paged_token_slots_decode(
         self,
         seq_lens: torch.Tensor,
@@ -727,6 +762,33 @@ class ScheduleBatch:
             error_msg = (
                 f"Decode out of memory. Try to lower your batch size.\n"
                 f"Try to allocate {len(seq_lens)} tokens.\n"
+                f"Avaliable tokens: {self.token_to_kv_pool_allocator.available_size() + self.tree_cache.evictable_size()}\n"
+                f"{self.token_to_kv_pool_allocator.available_size()=}\n"
+                f"{self.tree_cache.evictable_size()=}\n"
+            )
+            logger.error(error_msg)
+            raise RuntimeError(error_msg)
+        return out_cache_loc
+
+    def alloc_paged_token_slots_decode_hpu(
+        self,
+        reqs: List[Req],
+    ):
+        seq_ids = [req.req_pool_idx for req in reqs]
+        if (
+            self.token_to_kv_pool_allocator.available_size()
+            < len(seq_ids) * self.token_to_kv_pool_allocator.page_size
+        ):
+            if self.tree_cache is not None:
+                self.tree_cache.evict(
+                    len(seq_ids) * self.token_to_kv_pool_allocator.page_size,
+                )
+        out_cache_loc = self.token_to_kv_pool_allocator.alloc_decode(seq_ids)
+        out_cache_loc = torch.tensor(out_cache_loc, dtype=torch.int64, device=self.device)
+        if out_cache_loc is None:
+            error_msg = (
+                f"Decode out of memory. Try to lower your batch size.\n"
+                f"Try to allocate {len(seq_ids)} tokens.\n"
                 f"Avaliable tokens: {self.token_to_kv_pool_allocator.available_size() + self.tree_cache.evictable_size()}\n"
                 f"{self.token_to_kv_pool_allocator.available_size()=}\n"
                 f"{self.tree_cache.evictable_size()=}\n"
@@ -916,14 +978,19 @@ class ScheduleBatch:
         if self.token_to_kv_pool_allocator.page_size == 1:
             out_cache_loc = self.alloc_token_slots(extend_num_tokens)
         else:
-            last_loc = get_last_loc(
-                self.req_to_token_pool.req_to_token,
-                req_pool_indices_tensor,
-                prefix_lens_tensor,
-            )
-            out_cache_loc = self.alloc_paged_token_slots_extend(
-                prefix_lens_tensor, seq_lens_tensor, last_loc, extend_num_tokens
-            )
+            if self.device == "hpu":
+                out_cache_loc = self.alloc_paged_token_slots_extend_hpu(
+                    reqs, extend_lens
+                )
+            else:
+                last_loc = get_last_loc(
+                    self.req_to_token_pool.req_to_token,
+                    req_pool_indices_tensor,
+                    prefix_lens_tensor,
+                )
+                out_cache_loc = self.alloc_paged_token_slots_extend(
+                    prefix_lens_tensor, seq_lens_tensor, last_loc, extend_num_tokens
+                )
 
         # Set fields
         self.input_ids = input_ids_tensor
@@ -1076,9 +1143,13 @@ class ScheduleBatch:
                 token_indices = self.req_to_token_pool.req_to_token[
                     req.req_pool_idx, : seq_lens_cpu[idx]
                 ]
-                self.token_to_kv_pool_allocator.free(token_indices)
+                if self.device == "hpu":
+                    self.token_to_kv_pool_allocator.free(req.req_pool_idx)
+                else:
+                    self.token_to_kv_pool_allocator.free(token_indices)
                 self.req_to_token_pool.free(req.req_pool_idx)
             else:
+                raise NotImplementedError("Not implemented for non-ChunkCache")
                 # TODO: apply more fine-grained retraction
                 last_uncached_pos = len(req.prefix_indices)
                 token_indices = self.req_to_token_pool.req_to_token[
@@ -1187,9 +1258,14 @@ class ScheduleBatch:
             last_loc = self.req_to_token_pool.req_to_token[
                 self.req_pool_indices, self.seq_lens - 2
             ]
-            self.out_cache_loc = self.alloc_paged_token_slots_decode(
-                self.seq_lens, last_loc
-            )
+            if self.device == "hpu":
+                self.out_cache_loc = self.alloc_paged_token_slots_decode_hpu(
+                    self.reqs
+                )
+            else:
+                self.out_cache_loc = self.alloc_paged_token_slots_decode(
+                    self.seq_lens, last_loc
+                )
 
         self.req_to_token_pool.write(
             (self.req_pool_indices, locs), self.out_cache_loc.to(torch.int32)

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1511,6 +1511,25 @@ class ModelWorkerBatch:
     # If set, the output of the batch contains the hidden states of the run.
     capture_hidden_mode: CaptureHiddenMode = None
 
+    positions: Optional[torch.Tensor] = None
+    batch_size: Optional[int] = None
+    extend_start_loc: Optional[torch.Tensor] = None
+
+    # HPU-specific fields
+    page_size: Optional[int] = None
+    attn_bias: Optional[torch.Tensor] = None
+    seq_pos: Optional[torch.Tensor] = None
+    seq_idx: Optional[torch.Tensor] = None
+    valid_seq_len: Optional[torch.Tensor] = None
+    extend_seq_lens_padded: Optional[torch.Tensor] = None
+    real_batch_size: Optional[int] = None
+    use_contiguous_pa: Optional[bool] = None
+    block_list: Optional[torch.Tensor] = None
+    block_mapping: Optional[torch.Tensor] = None
+    block_groups: Optional[torch.Tensor] = None
+    block_usage: Optional[torch.Tensor] = None
+    block_scales: Optional[torch.Tensor] = None
+
 
 @triton.jit
 def write_req_to_token_pool_triton(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -90,7 +90,7 @@ from sglang.srt.managers.scheduler_output_processor_mixin import (
 )
 from sglang.srt.managers.session_controller import Session
 from sglang.srt.managers.tp_worker import TpModelWorker
-from sglang.srt.managers.tp_worker_overlap_thread import TpModelWorkerClient
+from sglang.srt.managers.tp_worker_overlap_thread import TpModelWorkerClient, TpModelWorkerClientSingelThread
 from sglang.srt.managers.utils import validate_input_length
 from sglang.srt.mem_cache.chunk_cache import ChunkCache
 from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
@@ -222,7 +222,7 @@ class Scheduler(SchedulerOutputProcessorMixin):
         if self.enable_overlap:
             TpWorkerClass = TpModelWorkerClient
         else:
-            TpWorkerClass = TpModelWorker
+            TpWorkerClass = TpModelWorkerClientSingelThread
 
         self.tp_worker = TpWorkerClass(
             server_args=server_args,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -294,9 +294,9 @@ class Scheduler(SchedulerOutputProcessorMixin):
         self.last_decode_stats_tic = time.time()
         self.last_prefill_stats_tic = time.time()
         self.return_health_check_ct = 0
-        self.current_stream = torch.get_device_module(self.device).current_stream()
-        if self.device == "cpu":
-            self.current_stream.synchronize = lambda: None  # No-op for CPU
+        self.current_stream = torch.get_device_module("cpu").current_stream()
+        # if self.device == "cpu":
+        self.current_stream.synchronize = lambda: None  # No-op for CPU
 
         # Init session info
         self.sessions: Dict[str, Session] = {}

--- a/python/sglang/srt/managers/scheduler_output_processor_mixin.py
+++ b/python/sglang/srt/managers/scheduler_output_processor_mixin.py
@@ -66,6 +66,7 @@ class SchedulerOutputProcessorMixin:
                     continue
 
                 if self.is_mixed_chunk and self.enable_overlap and req.finished():
+                    raise NotImplementedError("Not implemented for mixed chunk")
                     # Free the one delayed token for the mixed decode batch
                     j = len(batch.out_cache_loc) - len(batch.reqs) + i
                     self.token_to_kv_pool_allocator.free(batch.out_cache_loc[j : j + 1])
@@ -205,6 +206,7 @@ class SchedulerOutputProcessorMixin:
                 continue
 
             if self.enable_overlap and req.finished():
+                raise NotImplementedError("Not implemented for overlap")
                 # Free the one extra delayed token
                 if self.page_size == 1:
                     self.token_to_kv_pool_allocator.free(batch.out_cache_loc[i : i + 1])

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -170,6 +170,7 @@ class TpModelWorker:
     ) -> Tuple[LogitsProcessorOutput, Optional[torch.Tensor]]:
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)
         logits_output = self.model_runner.forward(forward_batch)
+        logits_output.trim_output(forward_batch.real_batch_size)
         if launch_done:
             launch_done.set()
 

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -184,11 +184,15 @@ class TpModelWorker:
             ## TODO: Need to somehow pad the model_worker_batch so that sampling works
             next_token_ids = self.model_runner.sample(logits_output, model_worker_batch)
         htorch.core.mark_step()
-        next_token_ids = next_token_ids.to("cpu")
+        # next_token_ids = next_token_ids.to("cpu")
         next_token_ids = next_token_ids[:forward_batch.real_batch_size]
 
-        # TODO: Need to return logits_output in the future
-        return None, next_token_ids
+        logits_output_copy: LogitsProcessorOutput = LogitsProcessorOutput(
+            next_token_logits=next_token_ids,
+            # hidden_states=logits_output.hidden_states.to("cpu")[:forward_batch.real_batch_size] if logits_output.hidden_states is not None else None
+        )
+
+        return logits_output_copy, next_token_ids
 
     def forward_batch_embedding(self, model_worker_batch: ModelWorkerBatch):
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -175,18 +175,20 @@ class TpModelWorker:
         htorch.core.mark_step()
         logits_output = self.model_runner.forward(hpu_forward_batch)
         htorch.core.mark_step()
-        logits_output.trim_output(forward_batch.real_batch_size)
         if launch_done:
             launch_done.set()
 
         if skip_sample:
             next_token_ids = None
         else:
+            ## TODO: Need to somehow pad the model_worker_batch so that sampling works
             next_token_ids = self.model_runner.sample(logits_output, model_worker_batch)
         htorch.core.mark_step()
         next_token_ids = next_token_ids.to("cpu")
+        next_token_ids = next_token_ids[:forward_batch.real_batch_size]
 
-        return logits_output, next_token_ids
+        # TODO: Need to return logits_output in the future
+        return None, next_token_ids
 
     def forward_batch_embedding(self, model_worker_batch: ModelWorkerBatch):
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -169,8 +169,8 @@ class TpModelWorker:
         skip_sample: bool = False,
     ) -> Tuple[LogitsProcessorOutput, Optional[torch.Tensor]]:
         forward_batch = ForwardBatch.init_new(model_worker_batch, self.model_runner)
-        from sglang.srt.model_executor.forward_batch_info import HPUForwardBatch
-        hpu_forward_batch = HPUForwardBatch.from_forward_batch(forward_batch)
+        from sglang.srt.model_executor.forward_batch_info import create_hpu_forward_batch
+        hpu_forward_batch = create_hpu_forward_batch(forward_batch)
         import habana_frameworks.torch as htorch
         htorch.core.mark_step()
         logits_output = self.model_runner.forward(hpu_forward_batch)
@@ -184,7 +184,7 @@ class TpModelWorker:
         else:
             next_token_ids = self.model_runner.sample(logits_output, model_worker_batch)
         htorch.core.mark_step()
-        next_token_ids = next_token_ids.to("cpu", non_blocking=True)
+        next_token_ids = next_token_ids.to("cpu")
 
         return logits_output, next_token_ids
 

--- a/python/sglang/srt/managers/tp_worker_overlap_thread.py
+++ b/python/sglang/srt/managers/tp_worker_overlap_thread.py
@@ -47,6 +47,246 @@ def resolve_future_token_ids(input_ids, future_token_ids_map):
         input_ids,
     )
 
+_is_hpu = is_hpu()
+
+_PAD_SLOT_ID = 0
+_PAD_BLOCK_ID = 0
+
+PREFILL_BUCKET_MIN = 512
+PREFILL_BUCKET_STEP = 512
+PREFILL_BUCKET_MAX = 4096
+
+DECODE_BLOCK_BUCKET_MIN = 128
+DECODE_BLOCK_BUCKET_STEP = 128
+DECODE_BLOCK_BUCKET_MAX = 4096
+
+DECODE_BATCH_BUCKET_MIN = 1
+DECODE_BATCH_BUCKET_STEP = 32
+DECODE_BATCH_BUCKET_MAX = 192
+
+import itertools
+import math
+import os
+from vllm_hpu_extension.bucketing import find_bucket
+from vllm_hpu_extension.ops import batch2block, block2batch
+from vllm.utils import make_tensor_with_pad
+def flatten(in_list):
+    return list(itertools.chain(*in_list))
+
+def make_cpu_tensor(data, max_len, pad, dtype, flat):
+    if flat:
+        data = [flatten(data)]
+    result = make_tensor_with_pad(data,
+                                  max_len=max_len,
+                                  pad=pad,
+                                  dtype=dtype,
+                                  device='cpu')
+    return result
+
+def gather_list(tensor, indices, pad_value):
+    result = [pad_value] * len(indices)
+    for i, idx in enumerate(indices):
+        if idx is not None:
+            result[i] = tensor[idx]
+    return result
+
+
+def round_up(value: int, k: int) -> int:
+    return (value + k - 1) // k * k
+
+
+def pad_list(input, k, v):
+    input_len = len(input)
+    target_len = round_up(input_len, k)
+    padding = target_len - input_len
+    return input + [v] * padding
+
+
+def _set_block_mapping(metadata, batch_size, device, dtype):
+    """Set block mapping using one-hot encoding of block groups."""
+
+    mask = torch.arange(0,
+                        metadata.page_size,
+                        device=device,
+                        dtype=torch.int32).unsqueeze(0)
+    mask = mask >= metadata.block_usage.unsqueeze(-1)
+    attn_bias = (torch.zeros_like(mask, dtype=dtype).masked_fill_(
+        mask, -math.inf))
+
+    # Handle out of bounds classes on CPU
+    block_groups = metadata.block_groups.to(torch.long)
+    block_mapping = torch.nn.functional.relu(block_groups)
+    block_mapping = torch.nn.functional.one_hot(block_mapping, num_classes=batch_size)
+    oob_values = block_groups.lt(0)
+    block_mapping.masked_fill_(oob_values.unsqueeze(-1), 0)
+    block_groups.masked_fill_(oob_values, batch_size)
+    return block_mapping.to(dtype), attn_bias, block_groups
+
+def _set_block_scales(metadata, device):
+    """Set block scales using batch2block and block2batch operations."""
+    block_mapping = metadata.block_mapping
+    ones = torch.ones((block_mapping.size(0),), device=device, dtype=block_mapping.dtype)
+    sums = batch2block(block2batch(ones, block_mapping), block_mapping)
+    block_scales = torch.reciprocal(torch.maximum(ones, sums))
+    return block_scales
+
+
+def _init_block_metadata(ret, model_runner, block_tables, slot_mapping, block_size):
+    """Initialize block metadata for HPU paged attention."""
+    device = "cpu"
+    dtype = model_runner.dtype
+
+    # Calculate block metadata
+    last_block_usage = [
+        slot % block_size + 1 for slot in slot_mapping
+    ]
+    block_groups = [[i] * len(bt) for i, bt in enumerate(block_tables)]
+    block_usage = [[block_size] * (len(bt) - 1) + [lbu]
+                    for bt, lbu in zip(block_tables, last_block_usage)
+                    if bt]
+    block_list = flatten(block_tables)
+    block_groups = flatten(block_groups)
+    block_usage = flatten(block_usage)
+    assert len(block_list) == len(block_groups)
+    assert len(block_list) == len(block_usage)
+
+    if ret.use_contiguous_pa:
+        # Pad block metadata if needed
+        block_bucket_size = max(max(block_list) + 1, len(block_list))
+        block_bucket_size = find_bucket(block_bucket_size, (DECODE_BLOCK_BUCKET_MIN, DECODE_BLOCK_BUCKET_STEP, DECODE_BLOCK_BUCKET_MAX))
+        indices = [None] * block_bucket_size
+        for i, bid in enumerate(block_list):
+            indices[bid] = i
+        padding_fn = lambda tensor, pad_value: gather_list(tensor, indices, pad_value)
+    else:
+        block_bucket_size = find_bucket(len(block_list), (DECODE_BLOCK_BUCKET_MIN, DECODE_BLOCK_BUCKET_STEP, DECODE_BLOCK_BUCKET_MAX))
+        padding_fn = lambda tensor, pad_value: pad_list(tensor, block_bucket_size, pad_value)
+
+    block_list = padding_fn(block_list, _PAD_BLOCK_ID)
+    block_groups = padding_fn(block_groups, -1)
+    block_usage = padding_fn(block_usage, 1)
+
+    # Convert to tensors
+    ret.block_list = torch.tensor(block_list, dtype=torch.long, device=device)
+    ret.block_groups = torch.tensor(block_groups, dtype=torch.long, device=device)
+    ret.block_usage = torch.tensor(block_usage, dtype=dtype, device=device)
+
+    # Set block mapping and scales
+    ret.block_mapping, ret.attn_bias, ret.block_groups = _set_block_mapping(ret, ret.batch_size, device, dtype)
+    ret.block_scales = _set_block_scales(ret, device)
+
+def make_hpu_attn_bias(seq_lens, max_prompt_len, dtype):
+    seq_pos = [list(range(sl)) for sl in seq_lens]
+    seq_idx = [[i] * sl for i, sl in enumerate(seq_lens)]
+    seq_pos = make_cpu_tensor(seq_pos,
+                                max_len=max_prompt_len,
+                                pad=-1,
+                                dtype=torch.long,
+                                flat=True)
+    seq_idx = make_cpu_tensor(seq_idx,
+                                max_len=max_prompt_len,
+                                pad=-1,
+                                dtype=torch.long,
+                                flat=True)
+    # q_seq_idx = seq_idx.unsqueeze(-1)
+    # kv_seq_idx = seq_idx.unsqueeze(-2)
+    # q_seq_pos = seq_pos.unsqueeze(-1)
+    # kv_seq_pos = seq_pos.unsqueeze(-2)
+    # seq_idx = q_seq_idx != kv_seq_idx
+    # seq_pos = kv_seq_pos > q_seq_pos
+    # attn_mask = seq_idx | seq_pos
+    
+    # attn_bias.masked_fill_(attn_mask, -math.inf)
+    # return attn_bias.unsqueeze(1)
+    attn_bias = torch.zeros(1, 1, max_prompt_len, max_prompt_len, dtype=dtype)
+    return attn_bias, seq_pos, seq_idx
+
+from sglang.srt.model_executor.forward_batch_info import clamp_position, compute_position_triton, compute_position_torch
+
+def create_hpu_specific_fields(ret: ModelWorkerBatch, model_runner):
+
+
+    if ret.forward_mode.is_decode():
+        if ret.positions is None:
+            ret.positions = clamp_position(ret.seq_lens)
+    else:
+        ret.extend_seq_lens = torch.tensor(
+            ret.extend_seq_lens, dtype=torch.int32
+        ).to("cpu", non_blocking=True)
+        ret.extend_prefix_lens = torch.tensor(
+            ret.extend_prefix_lens, dtype=torch.int32
+        ).to("cpu", non_blocking=True)
+        if model_runner.server_args.attention_backend not in ["torch_native", "hpu"]:
+            ret.extend_num_tokens = ret.extend_num_tokens
+            positions, ret.extend_start_loc = compute_position_triton(
+                ret.extend_prefix_lens,
+                ret.extend_seq_lens,
+                ret.extend_num_tokens,
+            )
+        else:
+            positions, ret.extend_start_loc = compute_position_torch(
+                ret.extend_prefix_lens, ret.extend_seq_lens
+            )
+        if ret.positions is None:
+            ret.positions = positions
+
+    ret.page_size = model_runner.token_to_kv_pool_allocator.page_size
+    if ret.forward_mode.is_extend():
+        seq_len_list = ret.extend_seq_lens
+        sum_seq_len = sum(seq_len_list)
+        max_prompt_len = find_bucket(sum_seq_len, (PREFILL_BUCKET_MIN, PREFILL_BUCKET_STEP, PREFILL_BUCKET_MAX))
+        ret.attn_bias, ret.seq_pos, ret.seq_idx = make_hpu_attn_bias(
+            seq_lens=seq_len_list,
+            max_prompt_len=max_prompt_len,
+            dtype=model_runner.dtype,
+        )
+        padding_len = max_prompt_len - sum_seq_len
+        max_prefill_seqs = model_runner.server_args.max_running_requests
+        batch_size = len(seq_len_list)
+        ret.input_ids = torch.nn.functional.pad(ret.input_ids, (0, padding_len), value=0)
+        ret.positions = torch.nn.functional.pad(ret.positions, (0, padding_len), value=0)
+        ret.valid_seq_len = torch.tensor(sum_seq_len, dtype=torch.int32)
+        ret.extend_seq_lens_padded = torch.nn.functional.pad(ret.extend_seq_lens, (0, max_prefill_seqs - batch_size), value=0)
+        ret.out_cache_loc = torch.nn.functional.pad(ret.out_cache_loc, (0, padding_len), value=0)
+        ret.real_batch_size = len(ret.seq_lens)
+        ret.batch_size = 1
+    else:
+        ret.use_contiguous_pa = os.environ.get('SGLANG_HPU_CONTIGUOUS_PA',
+                                        'true').lower() in ['true', '1']
+        batch_size = len(ret.seq_lens)
+        # Initialize block metadata for HPU paged attention
+        from sglang.srt.mem_cache.paged_allocator import HPUPagedTokenToKVPoolAllocator
+        paged_allocator: HPUPagedTokenToKVPoolAllocator = model_runner.token_to_kv_pool_allocator
+        padded_batch_size = find_bucket(batch_size, (DECODE_BATCH_BUCKET_MIN, DECODE_BATCH_BUCKET_STEP, DECODE_BATCH_BUCKET_MAX))
+        block_tables = []
+        for i in range(batch_size):
+            try:
+                block_tables.append(paged_allocator.block_manager.seq_info[ret.req_pool_indices[i].item()][0])
+            except Exception as e:
+                print(f"Error: {e}")
+                print(f"ret.req_pool_indices[i].item(): {ret.req_pool_indices[i].item()}")
+                print(f"paged_allocator.block_manager.seq_info: {paged_allocator.block_manager.seq_info}")
+                print(f"ret.input_ids: {ret.input_ids}")
+                print(f"")
+                raise e
+
+        for i in range(padded_batch_size - batch_size):
+            block_tables.append([_PAD_BLOCK_ID])
+
+        padding_len = padded_batch_size - len(ret.seq_lens)
+        input_ids = torch.nn.functional.pad(ret.input_ids, (0, padding_len), value=0)
+        positions = torch.nn.functional.pad(ret.positions, (0, padding_len), value=0)
+        ret.valid_seq_len = torch.ones(padded_batch_size, dtype=torch.int32)
+        ret.out_cache_loc = torch.nn.functional.pad(ret.out_cache_loc, (0, padding_len), value=0)
+        ret.real_batch_size = len(ret.seq_lens)
+        
+        slot_mapping = ret.out_cache_loc
+        block_size = paged_allocator.page_size
+        ret.input_ids = input_ids
+        ret.positions = positions
+        ret.batch_size = padded_batch_size
+        _init_block_metadata(ret, model_runner, block_tables, slot_mapping, block_size)
+    return ret
 
 class TpModelWorkerClient:
     """A tensor parallel model worker."""
@@ -109,7 +349,7 @@ class TpModelWorkerClient:
     def forward_thread_func(self):
         try:
             with torch.get_device_module(self.device).stream(self.forward_stream):
-                self.forward_thread_func_()
+                self.forward_thread_func_() 
         except Exception:
             traceback = get_exception_traceback()
             logger.error(f"TpModelWorkerClient hit an exception: {traceback}")
@@ -133,7 +373,10 @@ class TpModelWorkerClient:
 
             # Create event
             self.launch_done = threading.Event()
-            copy_done = torch.get_device_module(self.device).Event()
+            if not _is_hpu:
+                copy_done = torch.get_device_module(self.device).Event()
+            else:
+                copy_done = None
 
             # Resolve future tokens in the input
             input_ids = model_worker_batch.input_ids
@@ -164,13 +407,15 @@ class TpModelWorkerClient:
                     "cpu", non_blocking=True
                 )
             next_token_ids = next_token_ids.to("cpu", non_blocking=True)
-            copy_done.record()
+            if copy_done is not None:
+                copy_done.record()
 
             self.output_queue.put((copy_done, logits_output, next_token_ids))
 
     def resolve_batch_result(self, bid: int):
         copy_done, logits_output, next_token_ids = self.output_queue.get()
-        copy_done.synchronize()
+        if copy_done is not None:
+            copy_done.synchronize()
         self.launch_done.wait()
 
         if logits_output.next_token_logprobs is not None:
@@ -194,8 +439,11 @@ class TpModelWorkerClient:
             penalizer_orchestrator=None,
         )
 
+        create_hpu_specific_fields(model_worker_batch, self.worker.model_runner)
+
         # A cuda stream sync here to avoid the cuda illegal memory access error.
-        self.scheduler_stream.synchronize()
+        if not _is_hpu:
+            self.scheduler_stream.synchronize()
 
         # Push a new batch to the queue
         self.input_queue.put((model_worker_batch, self.future_token_ids_ct))
@@ -207,7 +455,7 @@ class TpModelWorkerClient:
             -(self.future_token_ids_ct + 1 + bs),
             -1,
             dtype=torch.int64,
-            device=self.device,
+            device="cpu",
         )
         self.future_token_ids_ct = (
             self.future_token_ids_ct + bs

--- a/python/sglang/srt/mem_cache/paged_allocator.py
+++ b/python/sglang/srt/mem_cache/paged_allocator.py
@@ -378,7 +378,7 @@ class BlockManager():
             del self.req_to_block_ids[req_id]
             del self.seq_info[req_id]
 
-class PagedTokenToKVPoolAllocator:
+class HPUPagedTokenToKVPoolAllocator:
 
     def __init__(self, size, page_size, dtype, device, kvcache):
         self.block_manager = BlockManager(page_size, size // page_size)
@@ -386,6 +386,7 @@ class PagedTokenToKVPoolAllocator:
         self.size = size
         self.dtype = dtype
         self.device = device
+        self.page_size = page_size
 
     def available_size(self):
         return self.block_manager.available_size()
@@ -394,8 +395,8 @@ class PagedTokenToKVPoolAllocator:
         slot_ids = []
         for seq_id, need_size in id_len_pairs:
             slots, new_blocks = self.block_manager.allocate(seq_id, need_size)
-            print(f"seq_id: {seq_id}, need_size: {need_size}, slots: {slots}")
-            print(f"block_manager.seq_info: {self.block_manager.seq_info}")
+            # print(f"seq_id: {seq_id}, need_size: {need_size}, slots: {slots}")
+            # print(f"block_manager.seq_info: {self.block_manager.seq_info}")
             slot_ids.extend(slots)
         return slot_ids
 
@@ -403,8 +404,8 @@ class PagedTokenToKVPoolAllocator:
         slot_ids = []
         for seq_id in seq_ids:
             slots, new_blocks = self.block_manager.allocate(seq_id, 1)
-            print(f"seq_id: {seq_id}, slots: {slots}")
-            print(f"block_manager.seq_info: {self.block_manager.seq_info}")
+            # print(f"seq_id: {seq_id}, slots: {slots}")
+            # print(f"block_manager.seq_info: {self.block_manager.seq_info}")
             slot_ids.extend(slots)
         return slot_ids
 

--- a/python/sglang/srt/mem_cache/paged_allocator.py
+++ b/python/sglang/srt/mem_cache/paged_allocator.py
@@ -20,6 +20,7 @@ Page-aligned memory pool.
 import torch
 import triton
 import triton.language as tl
+from typing import List, Optional, Tuple
 
 from sglang.srt.mem_cache.memory_pool import KVCache
 from sglang.srt.utils import get_bool_env_var, next_power_of_2
@@ -281,3 +282,138 @@ class PagedTokenToKVPoolAllocator:
         )
         self.is_in_free_group = False
         self.free_group = []
+
+
+class BlockManager():
+    def __init__(self, block_size, num_blocks):
+        self.block_size = block_size
+        self.num_blocks = num_blocks
+        self.free_blocks = list(range(1, num_blocks))
+        self.req_to_block_ids = {}
+        # Track sequence info: (block_ids, used_slots_in_last_block, slot_ids)
+        self.seq_info = {}
+
+    def clear(self):
+        self.free_blocks = list(range(1, self.num_blocks))
+        self.req_to_block_ids = {}
+        self.seq_info = {}
+
+    def available_size(self):
+        return len(self.free_blocks) * self.block_size
+
+    def allocate(self, req_id, need_size: int) -> Optional[List[int]]:
+        """Allocate slots for a sequence.
+
+        Args:
+            req_id: Request ID for the sequence
+            need_size: Number of tokens needed for the sequence
+
+        Returns:
+            List of slot IDs, or None if allocation failed
+        """
+        remaining_tokens = need_size
+        allocated_slots = []
+        new_blocks = []
+
+        # If sequence exists, try to fill remaining space in last block
+        if req_id in self.seq_info:
+            block_ids, used_slots, slot_ids = self.seq_info[req_id]
+            last_block = block_ids[-1]
+            available_in_last = self.block_size - used_slots
+
+            tokens_to_add = min(remaining_tokens, available_in_last)
+            if tokens_to_add > 0:
+                start_slot = last_block * self.block_size + used_slots
+                new_slots = list(range(start_slot, start_slot + tokens_to_add))
+                allocated_slots.extend(new_slots)
+                remaining_tokens -= tokens_to_add
+                used_slots += tokens_to_add
+                self.seq_info[req_id] = (block_ids, used_slots, slot_ids + new_slots)
+
+        # Need new blocks
+        if remaining_tokens > 0:
+            blocks_needed = (remaining_tokens + self.block_size - 1) // self.block_size
+
+            if blocks_needed > len(self.free_blocks):
+                return None
+
+            new_blocks = self.free_blocks[:blocks_needed]
+            self.free_blocks = self.free_blocks[blocks_needed:]
+
+            # Calculate slots in new blocks
+            for i, block_id in enumerate(new_blocks):
+                tokens_in_block = min(self.block_size, remaining_tokens)
+                start_slot = block_id * self.block_size
+                new_slots = list(range(start_slot, start_slot + tokens_in_block))
+                allocated_slots.extend(new_slots)
+                remaining_tokens -= tokens_in_block
+
+                # Update sequence info
+                if req_id in self.seq_info:
+                    existing_blocks, _, existing_slot_ids = self.seq_info[req_id]
+                    all_blocks = existing_blocks + [block_id]
+                    all_slot_ids = existing_slot_ids + new_slots
+                else:
+                    all_blocks = [block_id]
+                    all_slot_ids = new_slots
+                self.seq_info[req_id] = (all_blocks, tokens_in_block, all_slot_ids)
+
+            # Update block mapping
+            if req_id in self.req_to_block_ids:
+                self.req_to_block_ids[req_id].extend(new_blocks)
+            else:
+                self.req_to_block_ids[req_id] = new_blocks
+
+        return allocated_slots, new_blocks
+
+    def free(self, req_id):
+        """Free all blocks allocated to a request.
+
+        Args:
+            req_id: Request ID whose blocks should be freed
+        """
+        if req_id in self.req_to_block_ids:
+            freed_blocks = self.req_to_block_ids[req_id]
+            self.free_blocks.extend(freed_blocks)
+            del self.req_to_block_ids[req_id]
+            del self.seq_info[req_id]
+
+class PagedTokenToKVPoolAllocator:
+
+    def __init__(self, size, page_size, dtype, device, kvcache):
+        self.block_manager = BlockManager(page_size, size // page_size)
+        self.kvcache = kvcache
+        self.size = size
+        self.dtype = dtype
+        self.device = device
+
+    def available_size(self):
+        return self.block_manager.available_size()
+
+    def alloc_extend(self, id_len_pairs: List[Tuple[int, int]]):
+        slot_ids = []
+        for seq_id, need_size in id_len_pairs:
+            slots, new_blocks = self.block_manager.allocate(seq_id, need_size)
+            print(f"seq_id: {seq_id}, need_size: {need_size}, slots: {slots}")
+            print(f"block_manager.seq_info: {self.block_manager.seq_info}")
+            slot_ids.extend(slots)
+        return slot_ids
+
+    def alloc_decode(self, seq_ids: List[int]):
+        slot_ids = []
+        for seq_id in seq_ids:
+            slots, new_blocks = self.block_manager.allocate(seq_id, 1)
+            print(f"seq_id: {seq_id}, slots: {slots}")
+            print(f"block_manager.seq_info: {self.block_manager.seq_info}")
+            slot_ids.extend(slots)
+        return slot_ids
+
+    def free(self, req_ids: List[int]):
+        for req_id in req_ids:
+            self.block_manager.free(req_id)
+
+    def free_group_begin(self):
+        pass
+
+    def free_group_end(self):
+        pass

--- a/python/sglang/srt/mem_cache/paged_allocator.py
+++ b/python/sglang/srt/mem_cache/paged_allocator.py
@@ -409,9 +409,8 @@ class HPUPagedTokenToKVPoolAllocator:
             slot_ids.extend(slots)
         return slot_ids
 
-    def free(self, req_ids: List[int]):
-        for req_id in req_ids:
-            self.block_manager.free(req_id)
+    def free(self, req_id: int):
+        self.block_manager.free(req_id)
 
     def free_group_begin(self):
         pass

--- a/python/sglang/srt/mem_cache/paged_allocator.py
+++ b/python/sglang/srt/mem_cache/paged_allocator.py
@@ -417,3 +417,7 @@ class HPUPagedTokenToKVPoolAllocator:
 
     def free_group_end(self):
         pass
+
+    def clear(self):
+        self.block_manager.clear()
+

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -617,74 +617,56 @@ class ForwardBatch:
         )
         self.mrope_positions = self.mrope_positions.to(torch.int64)
 
-@dataclass
-class HPUForwardBatch:
-    forward_mode: ForwardMode
-    batch_size: int # this has to be padded batch size
-    input_ids: torch.Tensor
-    out_cache_loc: torch.Tensor
-    positions: torch.Tensor
-    attn_bias: torch.Tensor
-    valid_seq_len: torch.Tensor
-    extend_seq_lens: torch.Tensor
-    page_size: int
-    block_list: torch.Tensor
-    block_mapping: torch.Tensor
-    block_groups: torch.Tensor
-    block_usage: torch.Tensor
-    block_scales: torch.Tensor
-    attn_backend: AttentionBackend
-    token_to_kv_pool: KVCache
-    input_embeds: Optional[torch.Tensor] = None # do not change
-    extend_return_logprob: bool = False # do not change
-    padded_static_len: int = -1 # do not change
-    capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.NULL # do not change
+from typing import Optional
+from torch import Tensor
+from dataclasses import dataclass
+from collections import namedtuple
 
-    @classmethod
-    def from_forward_batch(cls, forward_batch: ForwardBatch):
-        return cls(
+HPUForwardBatch = namedtuple(
+    "HPUForwardBatch",
+    [
+        "forward_mode",
+        "batch_size",
+        "input_ids",
+        "out_cache_loc",
+        "positions",
+        "attn_bias",
+        "valid_seq_len",
+        "extend_seq_lens",
+        "page_size",
+        "block_list",
+        "block_mapping",
+        "block_groups",
+        "block_usage",
+        "block_scales",
+        "attn_backend",
+        "token_to_kv_pool",
+        "input_embeds",
+        "extend_return_logprob",
+        "padded_static_len",
+        "capture_hidden_mode",
+    ],
+    defaults=[None, False, -1, CaptureHiddenMode.NULL],
+)
+
+def create_hpu_forward_batch(forward_batch: ForwardBatch):
+    return HPUForwardBatch(
             forward_mode=forward_batch.forward_mode,
             batch_size=forward_batch.batch_size,
-            input_ids=forward_batch.input_ids.to("hpu", non_blocking=True),
-            out_cache_loc=forward_batch.out_cache_loc.to("hpu", non_blocking=True),
-            positions=forward_batch.positions.to("hpu", non_blocking=True),
-            attn_bias=forward_batch.attn_bias.to("hpu", non_blocking=True),
-            valid_seq_len=forward_batch.valid_seq_len.to("hpu", non_blocking=True) if forward_batch.valid_seq_len is not None else None,
-            extend_seq_lens=forward_batch.extend_seq_lens.to("hpu", non_blocking=True) if forward_batch.extend_seq_lens is not None else None,
+            input_ids=forward_batch.input_ids.to("hpu"),
+            out_cache_loc=forward_batch.out_cache_loc.to("hpu"),
+            positions=forward_batch.positions.to("hpu"),
+            attn_bias=forward_batch.attn_bias.to("hpu"),
+            valid_seq_len=forward_batch.valid_seq_len.to("hpu") if forward_batch.valid_seq_len is not None else None,
+            extend_seq_lens=forward_batch.extend_seq_lens.to("hpu") if forward_batch.extend_seq_lens is not None else None,
             page_size=forward_batch.page_size,
-            block_list=forward_batch.block_list.to("hpu", non_blocking=True) if forward_batch.block_list is not None else None,
-            block_mapping=forward_batch.block_mapping.to("hpu", non_blocking=True) if forward_batch.block_mapping is not None else None,
-            block_groups=forward_batch.block_groups.to("hpu", non_blocking=True) if forward_batch.block_groups is not None else None,
-            block_usage=forward_batch.block_usage.to("hpu", non_blocking=True) if forward_batch.block_usage is not None else None,
-            block_scales=forward_batch.block_scales.to("hpu", non_blocking=True) if forward_batch.block_scales is not None else None,
+            block_list=forward_batch.block_list.to("hpu") if forward_batch.block_list is not None else None,
+            block_mapping=forward_batch.block_mapping.to("hpu") if forward_batch.block_mapping is not None else None,
+            block_groups=forward_batch.block_groups.to("hpu") if forward_batch.block_groups is not None else None,
+            block_usage=forward_batch.block_usage.to("hpu") if forward_batch.block_usage is not None else None,
+            block_scales=forward_batch.block_scales.to("hpu") if forward_batch.block_scales is not None else None,
             attn_backend=forward_batch.attn_backend,
             token_to_kv_pool=forward_batch.token_to_kv_pool,
-        )
-
-    def __hash__(self) -> int:
-        return torch.hpu.graphs.input_hash(
-            (
-                self.forward_mode,
-                self.batch_size,
-                self.input_ids,
-                self.out_cache_loc,
-                self.positions,
-                self.attn_bias,
-                self.valid_seq_len,
-                self.extend_seq_lens,
-                self.page_size,
-                self.block_list,
-                self.block_mapping,
-                self.block_groups,
-                self.block_usage,
-                self.block_scales,
-                self.attn_backend,
-                self.token_to_kv_pool,
-                self.input_embeds,
-                self.extend_return_logprob,
-                self.padded_static_len,
-                self.capture_hidden_mode,
-            )
         )
 
 

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -663,13 +663,13 @@ HPUForwardBatch = namedtuple(
         "block_scales",
         "attn_backend",
         "token_to_kv_pool",
-        "use_contiguous_pa"
+        "use_contiguous_pa",
         "input_embeds",
         "extend_return_logprob",
         "padded_static_len",
         "capture_hidden_mode",
     ],
-    defaults=[None, False, -1, CaptureHiddenMode.NULL, True],
+    defaults=[None, False, -1, CaptureHiddenMode.NULL],
 )
 
 def create_hpu_forward_batch(forward_batch: ForwardBatch):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -38,6 +38,7 @@ import torch
 import triton
 import triton.language as tl
 import os
+import math
 
 from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
 from sglang.srt.utils import get_compiler_backend, is_hpu
@@ -51,20 +52,6 @@ if TYPE_CHECKING:
     from sglang.srt.speculative.eagle_utils import EagleDraftInput, EagleVerifyInput
     from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
-_PAD_SLOT_ID = 0
-_PAD_BLOCK_ID = 0
-
-PREFILL_BUCKET_MIN = 512
-PREFILL_BUCKET_STEP = 512
-PREFILL_BUCKET_MAX = 4096
-
-DECODE_BLOCK_BUCKET_MIN = 128
-DECODE_BLOCK_BUCKET_STEP = 128
-DECODE_BLOCK_BUCKET_MAX = 4096
-
-DECODE_BATCH_BUCKET_MIN = 1
-DECODE_BATCH_BUCKET_STEP = 32
-DECODE_BATCH_BUCKET_MAX = 192
 
 class ForwardMode(IntEnum):
     # Extend a sequence. The KV cache of the beginning part of the sequence is already computed (e.g., system prompt).
@@ -141,43 +128,6 @@ class CaptureHiddenMode(IntEnum):
 
     def is_last(self):
         return self == CaptureHiddenMode.LAST
-
-import itertools
-import math
-from vllm_hpu_extension.bucketing import find_bucket
-from vllm_hpu_extension.ops import batch2block, block2batch
-
-from vllm.utils import make_tensor_with_pad
-def flatten(in_list):
-    return list(itertools.chain(*in_list))
-
-def make_cpu_tensor(data, max_len, pad, dtype, flat):
-    if flat:
-        data = [flatten(data)]
-    result = make_tensor_with_pad(data,
-                                  max_len=max_len,
-                                  pad=pad,
-                                  dtype=dtype,
-                                  device='cpu')
-    return result
-
-def gather_list(tensor, indices, pad_value):
-    result = [pad_value] * len(indices)
-    for i, idx in enumerate(indices):
-        if idx is not None:
-            result[i] = tensor[idx]
-    return result
-
-
-def round_up(value: int, k: int) -> int:
-    return (value + k - 1) // k * k
-
-
-def pad_list(input, k, v):
-    input_len = len(input)
-    target_len = round_up(input_len, k)
-    padding = target_len - input_len
-    return input + [v] * padding
 
 
 @dataclass
@@ -294,81 +244,6 @@ class ForwardBatch:
     seq_idx: Optional[torch.Tensor] = None
     use_contiguous_pa: bool = True
 
-    @classmethod
-    def _set_block_mapping(cls, metadata, batch_size, device, dtype):
-        """Set block mapping using one-hot encoding of block groups."""
-
-        mask = torch.arange(0,
-                            metadata.page_size,
-                            device=device,
-                            dtype=torch.int32).unsqueeze(0)
-        mask = mask >= metadata.block_usage.unsqueeze(-1)
-        attn_bias = (torch.zeros_like(mask, dtype=dtype).masked_fill_(
-            mask, -math.inf))
-
-        # Handle out of bounds classes on CPU
-        block_groups = metadata.block_groups.to(torch.long)
-        block_mapping = torch.nn.functional.relu(block_groups)
-        block_mapping = torch.nn.functional.one_hot(block_mapping, num_classes=batch_size)
-        oob_values = block_groups.lt(0)
-        block_mapping.masked_fill_(oob_values.unsqueeze(-1), 0)
-        block_groups.masked_fill_(oob_values, batch_size)
-        return block_mapping.to(dtype), attn_bias, block_groups
-
-    @classmethod
-    def _set_block_scales(cls, metadata, device):
-        """Set block scales using batch2block and block2batch operations."""
-        block_mapping = metadata.block_mapping
-        ones = torch.ones((block_mapping.size(0),), device=device, dtype=block_mapping.dtype)
-        sums = batch2block(block2batch(ones, block_mapping), block_mapping)
-        block_scales = torch.reciprocal(torch.maximum(ones, sums))
-        return block_scales
-
-    @classmethod
-    def _init_block_metadata(cls, ret, model_runner, block_tables, slot_mapping, block_size):
-        """Initialize block metadata for HPU paged attention."""
-        device = "cpu"
-        dtype = model_runner.dtype
-
-        # Calculate block metadata
-        last_block_usage = [
-            slot % block_size + 1 for slot in slot_mapping
-        ]
-        block_groups = [[i] * len(bt) for i, bt in enumerate(block_tables)]
-        block_usage = [[block_size] * (len(bt) - 1) + [lbu]
-                      for bt, lbu in zip(block_tables, last_block_usage)
-                      if bt]
-        block_list = flatten(block_tables)
-        block_groups = flatten(block_groups)
-        block_usage = flatten(block_usage)
-        assert len(block_list) == len(block_groups)
-        assert len(block_list) == len(block_usage)
-
-        if ret.use_contiguous_pa:
-            # Pad block metadata if needed
-            block_bucket_size = max(max(block_list) + 1, len(block_list))
-            block_bucket_size = find_bucket(block_bucket_size, (DECODE_BLOCK_BUCKET_MIN, DECODE_BLOCK_BUCKET_STEP, DECODE_BLOCK_BUCKET_MAX))
-            indices = [None] * block_bucket_size
-            for i, bid in enumerate(block_list):
-                indices[bid] = i
-            padding_fn = lambda tensor, pad_value: gather_list(tensor, indices, pad_value)
-        else:
-            block_bucket_size = find_bucket(len(block_list), (DECODE_BLOCK_BUCKET_MIN, DECODE_BLOCK_BUCKET_STEP, DECODE_BLOCK_BUCKET_MAX))
-            padding_fn = lambda tensor, pad_value: pad_list(tensor, block_bucket_size, pad_value)
-
-        block_list = padding_fn(block_list, _PAD_BLOCK_ID)
-        block_groups = padding_fn(block_groups, -1)
-        block_usage = padding_fn(block_usage, 1)
-
-        # Convert to tensors
-        ret.block_list = torch.tensor(block_list, dtype=torch.long, device=device)
-        ret.block_groups = torch.tensor(block_groups, dtype=torch.long, device=device)
-        ret.block_usage = torch.tensor(block_usage, dtype=dtype, device=device)
-
-        # Set block mapping and scales
-        ret.block_mapping, ret.attn_bias, ret.block_groups = cls._set_block_mapping(ret, ret.batch_size, device, dtype)
-        ret.block_scales = cls._set_block_scales(ret, device)
-
 
     @classmethod
     def init_new(
@@ -376,7 +251,8 @@ class ForwardBatch:
         batch: ModelWorkerBatch,
         model_runner: ModelRunner,
     ):
-        device = model_runner.device
+        # device = model_runner.device
+        device = "cpu"
         extend_input_logprob_token_ids_gpu = None
         if batch.extend_input_logprob_token_ids is not None:
             extend_input_logprob_token_ids_gpu = (
@@ -442,30 +318,9 @@ class ForwardBatch:
 
         # Init position information
         if ret.forward_mode.is_decode():
-            if ret.positions is None:
-                ret.positions = clamp_position(batch.seq_lens)
             if ret.decode_seq_lens_cpu is None:
                 ret.decode_seq_lens_cpu = batch.decode_seq_lens
         else:
-            ret.extend_seq_lens = torch.tensor(
-                batch.extend_seq_lens, dtype=torch.int32
-            ).to(device, non_blocking=True)
-            ret.extend_prefix_lens = torch.tensor(
-                batch.extend_prefix_lens, dtype=torch.int32
-            ).to(device, non_blocking=True)
-            if model_runner.server_args.attention_backend not in ["torch_native", "hpu"]:
-                ret.extend_num_tokens = batch.extend_num_tokens
-                positions, ret.extend_start_loc = compute_position_triton(
-                    ret.extend_prefix_lens,
-                    ret.extend_seq_lens,
-                    ret.extend_num_tokens,
-                )
-            else:
-                positions, ret.extend_start_loc = compute_position_torch(
-                    ret.extend_prefix_lens, ret.extend_seq_lens
-                )
-            if ret.positions is None:
-                ret.positions = positions
             ret.extend_prefix_lens_cpu = batch.extend_prefix_lens
             ret.extend_seq_lens_cpu = batch.extend_seq_lens
             ret.extend_logprob_start_lens_cpu = batch.extend_logprob_start_lens
@@ -477,81 +332,25 @@ class ForwardBatch:
         if model_runner.server_args.lora_paths is not None:
             model_runner.lora_manager.prepare_lora_batch(ret)
 
-        seq_len_list = ret.extend_seq_lens_cpu
-        if model_runner.server_args.attention_backend == "hpu":
-            ret.page_size = model_runner.token_to_kv_pool_allocator.page_size
-            if ret.forward_mode.is_extend():
-                sum_seq_len = sum(seq_len_list)
-                max_prompt_len = find_bucket(sum_seq_len, (PREFILL_BUCKET_MIN, PREFILL_BUCKET_STEP, PREFILL_BUCKET_MAX))
-                ret.attn_bias, ret.seq_pos, ret.seq_idx = cls.make_hpu_attn_bias(
-                    seq_lens=seq_len_list,
-                    max_prompt_len=max_prompt_len,
-                    dtype=model_runner.dtype,
-                )
-                padding_len = max_prompt_len - sum_seq_len
-                max_prefill_seqs = model_runner.server_args.max_running_requests
-                ret.input_ids = torch.nn.functional.pad(ret.input_ids, (0, padding_len), value=0)
-                ret.positions = torch.nn.functional.pad(ret.positions, (0, padding_len), value=0)
-                ret.valid_seq_len = torch.tensor(sum_seq_len, dtype=torch.int32)
-                ret.extend_seq_lens = torch.nn.functional.pad(ret.extend_seq_lens, (0, max_prefill_seqs - ret.batch_size), value=0)
-                ret.out_cache_loc = torch.nn.functional.pad(ret.out_cache_loc, (0, padding_len), value=0)
-                ret.real_batch_size = ret.batch_size
-                ret.batch_size = 1
-            else:
-                ret.use_contiguous_pa = os.environ.get('SGLANG_HPU_CONTIGUOUS_PA',
-                                                'true').lower() in ['true', '1']
-                # Initialize block metadata for HPU paged attention
-                from sglang.srt.mem_cache.paged_allocator import HPUPagedTokenToKVPoolAllocator
-                paged_allocator: HPUPagedTokenToKVPoolAllocator = model_runner.token_to_kv_pool_allocator
-                padded_batch_size = find_bucket(ret.batch_size, (DECODE_BATCH_BUCKET_MIN, DECODE_BATCH_BUCKET_STEP, DECODE_BATCH_BUCKET_MAX))
-                block_tables = []
-                for i in range(ret.batch_size):
-                    block_tables.append(paged_allocator.block_manager.seq_info[ret.req_pool_indices[i].item()][0])
-
-                for i in range(padded_batch_size - ret.batch_size):
-                    block_tables.append([_PAD_BLOCK_ID])
-
-                padding_len = padded_batch_size - ret.batch_size
-                input_ids = torch.nn.functional.pad(ret.input_ids, (0, padding_len), value=0)
-                positions = torch.nn.functional.pad(ret.positions, (0, padding_len), value=0)
-                ret.valid_seq_len = torch.ones(padded_batch_size, dtype=torch.int32)
-                ret.out_cache_loc = torch.nn.functional.pad(ret.out_cache_loc, (0, padding_len), value=0)
-                ret.real_batch_size = ret.batch_size
-                
-                slot_mapping = ret.out_cache_loc
-                block_size = paged_allocator.page_size
-                ret.input_ids = input_ids
-                ret.positions = positions
-                ret.batch_size = padded_batch_size
-                cls._init_block_metadata(ret, model_runner, block_tables, slot_mapping, block_size)
-        return ret
-
-    @classmethod
-    def make_hpu_attn_bias(cls, seq_lens, max_prompt_len, dtype):
-        seq_pos = [list(range(sl)) for sl in seq_lens]
-        seq_idx = [[i] * sl for i, sl in enumerate(seq_lens)]
-        seq_pos = make_cpu_tensor(seq_pos,
-                                  max_len=max_prompt_len,
-                                  pad=-1,
-                                  dtype=torch.long,
-                                  flat=True)
-        seq_idx = make_cpu_tensor(seq_idx,
-                                  max_len=max_prompt_len,
-                                  pad=-1,
-                                  dtype=torch.long,
-                                  flat=True)
-        # q_seq_idx = seq_idx.unsqueeze(-1)
-        # kv_seq_idx = seq_idx.unsqueeze(-2)
-        # q_seq_pos = seq_pos.unsqueeze(-1)
-        # kv_seq_pos = seq_pos.unsqueeze(-2)
-        # seq_idx = q_seq_idx != kv_seq_idx
-        # seq_pos = kv_seq_pos > q_seq_pos
-        # attn_mask = seq_idx | seq_pos
         
-        # attn_bias.masked_fill_(attn_mask, -math.inf)
-        # return attn_bias.unsqueeze(1)
-        attn_bias = torch.zeros(1, 1, max_prompt_len, max_prompt_len, dtype=dtype)
-        return attn_bias, seq_pos, seq_idx
+        if model_runner.server_args.attention_backend == "hpu":
+            ret.positions = batch.positions
+            ret.batch_size = batch.batch_size
+            ret.extend_start_loc = batch.extend_start_loc
+            ret.page_size = batch.page_size
+            ret.attn_bias = batch.attn_bias
+            ret.seq_pos = batch.seq_pos
+            ret.seq_idx = batch.seq_idx
+            ret.valid_seq_len = batch.valid_seq_len
+            ret.extend_seq_lens = batch.extend_seq_lens_padded
+            ret.block_list = batch.block_list
+            ret.block_mapping = batch.block_mapping
+            ret.block_groups = batch.block_groups
+            ret.block_usage = batch.block_usage
+            ret.block_scales = batch.block_scales
+            ret.use_contiguous_pa = batch.use_contiguous_pa
+            ret.real_batch_size = batch.real_batch_size
+        return ret
 
     def get_merged_image_inputs(self) -> Optional[ImageInputs]:
         """

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -856,6 +856,12 @@ class ModelRunner:
             )
 
             self.attn_backend = TorchNativeAttnBackend(self)
+        elif self.server_args.attention_backend == "hpu":
+            from sglang.srt.layers.attention.hpu_attn_backend import (
+                HPUAttnBackend,
+            )
+
+            self.attn_backend = HPUAttnBackend(self)
         elif self.server_args.attention_backend == "flashinfer_mla":
             from sglang.srt.layers.attention.flashinfer_mla_backend import (
                 FlashInferMLAAttnBackend,

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -53,7 +53,7 @@ from sglang.srt.mem_cache.memory_pool import (
     ReqToTokenPool,
     TokenToKVPoolAllocator,
 )
-from sglang.srt.mem_cache.paged_allocator import PagedTokenToKVPoolAllocator
+from sglang.srt.mem_cache.paged_allocator import PagedTokenToKVPoolAllocator, HPUPagedTokenToKVPoolAllocator
 from sglang.srt.model_executor.cuda_graph_runner import CudaGraphRunner
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_loader import get_model

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -87,6 +87,41 @@ logger = logging.getLogger(__name__)
 SGLANG_CI_SMALL_KV_SIZE = os.getenv("SGLANG_CI_SMALL_KV_SIZE", None)
 UNBALANCED_MODEL_LOADING_TIMEOUT_S = 300
 
+import math
+
+def make_hpu_attn_bias(seq_pos, seq_idx, dtype):
+    q_seq_idx = seq_idx.unsqueeze(-1)
+    kv_seq_idx = seq_idx.unsqueeze(-2)
+    q_seq_pos = seq_pos.unsqueeze(-1)
+    kv_seq_pos = seq_pos.unsqueeze(-2)
+    seq_idx = q_seq_idx != kv_seq_idx
+    seq_pos = kv_seq_pos > q_seq_pos
+    attn_mask = seq_idx | seq_pos
+    attn_bias = torch.zeros_like(attn_mask, dtype=dtype)
+    attn_bias.masked_fill_(attn_mask, -math.inf)
+    return attn_bias.unsqueeze(1)
+    
+
+class HPUAdapter:
+
+    def __init__(self, model, dtype) -> None:
+        self.model = model
+        self.dtype = dtype
+    
+
+    def __getattr__(self, name):
+        return getattr(self.model, name)
+
+    def forward(self, *args, **kwargs):
+        assert len(args) == 3, "Only three arguments are supported"
+        input_batch = args[2]
+        if input_batch.forward_mode.is_extend():
+            input_batch.attn_bias.copy_(make_hpu_attn_bias(input_batch.seq_pos, input_batch.seq_idx, self.dtype))
+        return self.model(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        return self.forward(*args, **kwargs)
+
 
 class ModelRunner:
     """ModelRunner runs the forward passes of the models."""
@@ -180,9 +215,9 @@ class ModelRunner:
 
         import habana_frameworks.torch as htorch
         self.model = htorch.hpu.wrap_in_hpu_graph(
-            self.model,
+            HPUAdapter(self.model, self.dtype),
             disable_tensor_cache=True,
-        ) if htorch.utils.internal.is_lazy() else self.model
+        ) if htorch.utils.internal.is_lazy() else HPUAdapter(self.model, self.dtype)
 
         # Apply torchao quantization
         torchao_applied = getattr(self.model, "torchao_applied", False)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -310,6 +310,9 @@ class ServerArgs:
         # AMD-specific Triton attention KV splits default number
         if is_hip():
             self.triton_attention_num_kv_splits = 16
+        
+        if self.max_running_requests is None:
+            self.max_running_requests = 128
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -244,7 +244,7 @@ class ServerArgs:
 
         # Choose kernel backends
         if self.device == "hpu":
-            self.attention_backend = "torch_native"
+            self.attention_backend = "hpu"
             self.sampling_backend = "pytorch"
 
         if self.attention_backend is None:


### PR DESCRIPTION
# Experimental support for hpu sglang 

**(I haven't test acc but the output seems to make sense)**

## Docker setup example

```bash
docker run -dit \
     --runtime=habana --name "sglang-1.20" \
     -v `pwd`:/workspace/vllm \
     -v /scratch-1/models:/data \
     -e HF_HOME=/data -e HABANA_VISIBLE_DEVICES=all \
     -e OMPI_MCA_btl_vader_single_copy_mechanism=none \
     -e HABANA_VISIBLE_DEVICES=all --cap-add=sys_nice \
     --ipc=host --net=host \
     [vault.habana.ai/gaudi-docker/1.20.0/ubuntu22.04/habanalabs/pytorch-installer-2.6.0:latest](http://vault.habana.ai/gaudi-docker/1.20.0/ubuntu22.04/habanalabs/pytorch-installer-2.6.0:latest) \
     /bin/bash
```

## Installation inside the docker

### Install vllm-fork
```bash
git clone https://github.com/HabanaAI/vllm-fork.git
cd vllm-fork
git checkout v0.6.6.post1+Gaudi-1.20.0
python setup.py develop
git checkout 284d51702e3a74f99d19e4506e6a8227ff803706
pip install -r requirements-hpu.txt
```

### Install SGlang

```bash
git clone https://github.com/yangw1234/sglang_upstream_fork.git
git checkout overlap_schedule_backup
pip install -e "python[all_hpu]"
```

### Run example output

```bash
PT_HPU_ENABLE_LAZY_COLLECTIVES=true PT_HPU_LAZY_MODE=1 python examples/runtime/engine/offline_batch_inference.py \
    --device hpu \
    --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
    --page-size 128 \
    --disable-radix-cache \
    --max-prefill-tokens 2048 \
    --tp-size 1
```

### Run benchmarks

```bash
PT_HPU_ENABLE_LAZY_COLLECTIVES=true PT_HPU_LAZY_MODE=1 python3 -m sglang.bench_offline_throughput \
    --model-path meta-llama/Meta-Llama-3.1-8B-Instruct \
    --num-prompts 128 \
    --random-input-len 1024 \
    --random-output-len 1024 \
    --device hpu \
    --page-size 128 \
    --disable-radix-cache \
    --max-prefill-tokens 2048 \
    --random-range-ratio 1.0 \
    --dataset-name random
```