### PR TITLE
Use CPU for scheduler when HPU is detected

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -289,12 +289,20 @@ class Scheduler(
             self.max_req_len,
             self.max_req_input_len,
             self.random_seed,
-            self.device,
+            device,
             worker_global_server_args_dict,
             _,
             _,
             _,
         ) = self.tp_worker.get_worker_info()
+        
+        # Use CPU for scheduler when the underlying accelerator is HPU
+        if _is_hpu:
+            self.device = "cpu"
+            logger.info("HPU detected. Using CPU for scheduler operations.")
+        else:
+            self.device = device
+            
         self.tp_cpu_group = self.tp_worker.get_tp_cpu_group()
         self.attn_tp_cpu_group = self.tp_worker.get_attention_tp_cpu_group()
         self.pad_input_ids_func = self.tp_worker.get_pad_input_ids_func()

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -113,6 +113,7 @@ from sglang.srt.managers.utils import validate_input_length
 from sglang.srt.mem_cache.chunk_cache import ChunkCache
 from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
 from sglang.srt.mem_cache.radix_cache import RadixCache
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.metrics.collector import SchedulerMetricsCollector, SchedulerStats
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.reasoning_parser import ReasoningParser
@@ -477,9 +478,23 @@ class Scheduler(
     def init_memory_pool_and_cache(self):
         server_args = self.server_args
 
-        self.req_to_token_pool, self.token_to_kv_pool_allocator = (
+        # Get memory pools from the worker
+        req_to_token_pool, self.token_to_kv_pool_allocator = (
             self.tp_worker.get_memory_pool()
         )
+        
+        # If HPU is detected, ensure req_to_token_pool is on CPU
+        if _is_hpu and req_to_token_pool.device != "cpu":
+            logger.info("HPU detected. Moving req_to_token_pool to CPU for scheduler operations.")
+            # Create a new pool on CPU with the same parameters
+            self.req_to_token_pool = ReqToTokenPool(
+                size=req_to_token_pool.size,
+                max_context_len=req_to_token_pool.max_context_len,
+                device="cpu",
+                enable_memory_saver=self.server_args.enable_memory_saver,
+            )
+        else:
+            self.req_to_token_pool = req_to_token_pool
 
         if (
             server_args.chunked_prefill_size is not None

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -803,10 +803,22 @@ class ModelRunner:
             )
 
         if self.req_to_token_pool is None:
+            # Check if we're running on HPU
+            is_hpu = False
+            try:
+                import habana_frameworks.torch as ht
+                is_hpu = True
+                logger.info("HPU detected. Using CPU for req_to_token_pool.")
+            except ImportError:
+                pass
+            
+            # Use CPU device for req_to_token_pool when running on HPU
+            pool_device = "cpu" if is_hpu else self.device
+            
             self.req_to_token_pool = ReqToTokenPool(
                 size=max_num_reqs + 1,
                 max_context_len=self.model_config.context_len + 4,
-                device=self.device,
+                device=pool_device,
                 enable_memory_saver=self.server_args.enable_memory_saver,
             )
         else:


### PR DESCRIPTION
This PR modifies the scheduler to use CPU when the underlying accelerator is an HPU. This change helps improve compatibility and performance when running on HPU hardware.