### PR TITLE
Add HPU support and use CPU scheduler for HPU devices

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -328,6 +328,11 @@ class Scheduler(
         self.last_decode_stats_tic = time.time()
         self.last_prefill_stats_tic = time.time()
         self.return_health_check_ct = 0
+        # Use CPU scheduler for HPU devices
+        if self.device == "hpu":
+            self.device = "cpu"
+            logger.info("HPU device detected, using CPU scheduler")
+            
         self.current_stream = torch.get_device_module(self.device).current_stream()
         if self.device == "cpu":
             self.current_stream.synchronize = lambda: None  # No-op for CPU


### PR DESCRIPTION
This PR adds HPU support for rotary embedding and layernorm, and modifies the scheduler to use CPU when the device is HPU.